### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/cloud/marathon/connector/MarathonCloudConnector.java
+++ b/src/main/java/org/springframework/cloud/marathon/connector/MarathonCloudConnector.java
@@ -36,7 +36,7 @@ public class MarathonCloudConnector extends AbstractCloudConnector<Task> {
 		String marathonHost = environment.getEnvValue("SPRING_CLOUD_MARATHON_HOST");
 		if (marathonHost == null) {
 			// Default value for mesos/playa
-			marathonHost = "http://10.141.141.10:8080";
+			marathonHost = "https://10.141.141.10:8080";
 		}
 		log.info("Using Marathon Host: " + marathonHost);
 		this.marathon = MarathonClient.getInstance(marathonHost);


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://10.141.141.10:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://10.141.141.10:8080 ([https](https://10.141.141.10:8080) result ConnectTimeoutException).